### PR TITLE
Fix compiler warning

### DIFF
--- a/src/Adafruit_GFX_RK.h
+++ b/src/Adafruit_GFX_RK.h
@@ -3,4 +3,4 @@
 
 #include "Adafruit_GFX.h"
 
-#endif __ADAFRUIT_GFX_RK_H
+#endif // __ADAFRUIT_GFX_RK_H


### PR DESCRIPTION
Fixes
```
lib/Adafruit_GFX_RK/src/Adafruit_GFX_RK.h:6:8: warning: extra tokens at end of #endif directive [enabled by default]
 #endif __ADAFRUIT_GFX_RK_H
```